### PR TITLE
3.6.0-beta.5

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,15 +32,11 @@ jobs:
 
       - name: Publish to npm
         if: github.ref_name == 'main'
-        run: npm publish
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: yarn npm publish --otp ${{secrets.NPM_TOKEN }}
       
       - name: Publish to npm beta
         if: github.ref_name == 'beta'
-        run: npm publish --tag beta
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: yarn npm publish --tag beta --otp ${{secrets.NPM_TOKEN }}
 
   publish_release:
     needs: publish

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.6.0-beta.5
+* switched to yarn with `--otp` flag to publish to npm
+
 ## 3.6.0-beta.4
 * Fixed the env variable name mixup
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adga",
-  "version": "3.6.0-beta.4",
+  "version": "3.6.0-beta.5",
   "description": "Unofficial ADGA (https://app.adga.org/) node.js library (SDK)",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
## 3.6.0-beta.5
* switched to yarn with `--otp` flag to publish to npm
