### PR TITLE
3.6.1-beta.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.6.1-beta.1
+* Updated valid search options for the CDCB
+
 ## 3.6.0-beta.7
 * Updated Github Token permissons to allow publishing to npm with provenance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.6.1-beta.2
+* Fixed a bug in the CDCB `getLactationsTestDate()` url that caused the search to fail
+
 ## 3.6.1-beta.1
 * Updated valid search options for the CDCB
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.6.1-beta.3
+* EXpanded the types allowed for the search query to include `number` in addition to `string` 
+
 ## 3.6.1-beta.2
 * Fixed a bug in the CDCB `getLactationsTestDate()` url that caused the search to fail
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adga",
-  "version": "3.6.0-beta.7",
+  "version": "3.6.1-beta.3",
   "description": "Unofficial ADGA (https://app.adga.org/) node.js library (SDK)",
   "license": "Apache-2.0",
   "repository": {

--- a/src/CDCB/index.ts
+++ b/src/CDCB/index.ts
@@ -81,7 +81,7 @@ export default class CDCB {
     });
     return (await server.get<Login>('https://webconnect.uscdcb.com/api/auth/public-token',)).data;
   }
-  async searchAnimal(searchType: QuerySeachOptions, query: string): Promise<AnimalQuery> {
+  async searchAnimal(searchType: QuerySeachOptions, query: string | number): Promise<AnimalQuery> {
     return (await this.server.get<AnimalQuery>(`/common/search-animal/${searchType}/GOAT/${query}/,`)).data;
   }
 

--- a/src/CDCB/index.ts
+++ b/src/CDCB/index.ts
@@ -101,7 +101,7 @@ export default class CDCB {
     if (typeof animalIdOrAnimal === 'object') {
       const animal = animalIdOrAnimal as Animal;
       const lactation = animalKeyOrLactation as AnimalLactation;
-      return (await this.server.get<LactationTestDate>(`/lactation/get-lactations-test-date/${animal.animalId}/${animal.animKey}/${lactation.lt}/${animal.sexCode}/${lactation.calvPdate}/${lactation.herdCode}`)).data;
+      return (await this.server.get<LactationTestDate>(`/lactation/get-lactations-test-date/${animal.animalId}/${animal.animKey}/1/${animal.sexCode}/${lactation.calvPdate}/${lactation.herdCode}`)).data;
     } else {
       return (await this.server.get<LactationTestDate>(`/lactation/get-lactations-test-date/${animalIdOrAnimal}/${animalKeyOrLactation}/1/F/${calvPdate}/${herdCode}`)).data;
     }

--- a/src/CDCB/interfaces.ts
+++ b/src/CDCB/interfaces.ts
@@ -5,24 +5,14 @@ export interface Login {
   status: 'success';
 }
 export enum QuerySeachOptions {
-  /** Animal ID (12 bytes) */
-  ANIM_KEY_12 = 'ANIM_KEY_12',
-  /** Animal ID (15 bytes) */
-  ANIM_KEY_15 = 'ANIM_KEY_15',
+  /** Animal ID - Last 6 Characters */
+  ANIM_KEY_6 = 'ANIM_KEY_6',
   /** Animal ID (17 bytes)/ Animal ID + Sex Code (18 bytes) */
-  ANIM_KEY_17 = 'ANIM_KEY_17',
-  /** Animal Interbull ID (19 bytes) */
-  ITB_ID = 'ITB_ID',
-  /** Sample ID (20 bytes max) */
-  SAMPLE_ID_SEX = 'SAMPLE_ID_SEX',
-  /** NAAB Code */
-  NAAB_CODE = 'NAAB_CODE',
+  ANIM_KEY_17_ANIM_KEY_17_SEX = 'ANIM_KEY_17_ANIM_KEY_17_SEX',
   /** Short Name */
   SHORT_NAME = 'SHORT_NAME',
   /** Partial Full Name */
   PARTIAL_FULL_NAME = 'PARTIAL_FULL_NAME',
-  /** Herd + Cow Control Number */
-  HERD_CTRL_NUM = 'HERD_CTRL_NUM',
   /** Herd ID */
   HERD_ID = 'HERD_ID',
 };


### PR DESCRIPTION
## 3.6.1-beta.3
* EXpanded the types allowed for the search query to include `number` in addition to `string` 

## 3.6.1-beta.2
* Fixed a bug in the CDCB `getLactationsTestDate()` url that caused the search to fail

## 3.6.1-beta.1
* Updated valid search options for the CDCB
