### PR TITLE
3.6.2-beta.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.6.2-beta.2
+* Fixed a bug preventing the CDCB functions from being able to import
+
 ## 3.6.2-beta.1
 * Singificantly imporved the types for the return values of the CDCB functions
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adga",
-  "version": "3.6.2-beta.1",
+  "version": "3.6.2-beta.2",
   "description": "Unofficial ADGA (https://app.adga.org/) node.js library (SDK)",
   "license": "Apache-2.0",
   "repository": {
@@ -11,6 +11,10 @@
     "url": "https://github.com/bloomkd46/ADGA/issues"
   },
   "main": "dist/index.js",
+  "exports": {
+    "./cdcb": "./dist/cdcb/index.js",
+    ".": "./dist/index.js"
+  },
   "scripts": {
     "lint": "eslint src/**.ts --max-warnings=0 --fix",
     "build": "rimraf ./dist && tsc",


### PR DESCRIPTION
## 3.6.2-beta.2
* Fixed a bug preventing the CDCB functions from being able to import
