### PR TITLE
3.8.0-beta.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.8.0-beta.1
+* The CDCB library can now be imported using `import { CDCB } from 'adga/CDCB'` or `import CDCB from 'adga/cdcb'`
+  * It was previously only available as `import { CDCB } from 'adga/cdcb'`
+
 ## 3.7.2-beta.1
 * Made `getOwnedGoats()` significantly faster
   * It originally fetched all owned goats at once, which worked fine when this library was first created, but ADGA recently changed their system so that the more that you request, the longer it takes to respond.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adga",
-  "version": "3.7.2-beta.1",
+  "version": "3.8.0-beta.1",
   "description": "Unofficial ADGA (https://app.adga.org/) node.js library (SDK)",
   "license": "Apache-2.0",
   "repository": {
@@ -14,6 +14,7 @@
   "types": "dist/index.d.ts",
   "exports": {
     "./cdcb": "./CDCB/index.js",
+    "./CDCB": "./CDCB/index.js",
     ".": "./index.js"
   },
   "scripts": {


### PR DESCRIPTION
## 3.8.0-beta.1
* The CDCB library can now be imported using `import { CDCB } from 'adga/CDCB'` or `import CDCB from 'adga/cdcb'`
  * It was previously only available as `import { CDCB } from 'adga/cdcb'`
